### PR TITLE
Fixed browserify and npm integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,5 @@
   "scripts": {
     "test": "grunt test"
   },
-  "browser": "./dist/highcharts-ng.js"
+  "main": "./dist/highcharts-ng"
 }


### PR DESCRIPTION
Switched from using `"browser"` field to `"main"` field for indicating where the source should be found. As per [the browserify docs](https://www.npmjs.com/package/browserify#packagejson) it uses `"main"` in preference to `"browser"`, and this also allows it to work with node `resolve`, which is useful for building separate Browserify bundles using the API:

``` javascript
var nodeResolve = require('resolve');
var resolved = nodeResolve.sync('highcharts-ng'); // this fails with "browser" but not with "main"
brorwserify.require(resolved, {expose: 'highcharts-ng'} ); // use browserify API for building 3rd party bundle
```
